### PR TITLE
Allow explicit checking and unchecking

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ You can set a default abilitation (used when you reset a form) via the `data-def
 
     $('input[type="checkbox"]').checkbox('click'); // change input's state
     $('input[type="checkbox"]').checkbox('toggleEnabled'); // change input's enabled
+    $('input[type="checkbox"]').checkbox('check'); // change input's state to checked
+    $('input[type="checkbox"]').checkbox('unCheck'); // change input's state to unchecked
     
 ## Copyright and license
 

--- a/js/bootstrap-checkbox.js
+++ b/js/bootstrap-checkbox.js
@@ -233,7 +233,19 @@
         	this.options = $.extend({}, this.options, options);
         	this.$element.next().remove();
         	this._createButtons();
-       }
+        },
+        
+        check: function(event){
+        	this.$element.prop("checked", true);
+        	this.$element.prop("indeterminate", false);
+        	this.checkChecked();
+        },
+        
+        unCheck: function(event){
+        	this.$element.prop("checked", false);
+        	this.$element.prop("indeterminate", false);
+        	this.checkChecked();
+        }
     };
 
     $.fn.checkbox = function(option, event) {


### PR DESCRIPTION
These functions make it simpler to explicitly check or uncheck the checkbox (versus toggling its state via the "click" function).
